### PR TITLE
Update cTrader Layer to support browser usage

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
             "version": "1.0.1",
             "license": "MIT",
             "dependencies": {
-                "@reiryoku/ctrader-layer": "^2.0.0"
+                "@reiryoku/ctrader-layer": "^2.1.0"
             },
             "devDependencies": {
                 "@reiryoku/eslint-config-reiryoku": "^1.0.0",
@@ -930,9 +930,9 @@
             }
         },
         "node_modules/@reiryoku/ctrader-layer": {
-            "version": "2.0.0",
-            "resolved": "https://registry.npmjs.org/@reiryoku/ctrader-layer/-/ctrader-layer-2.0.0.tgz",
-            "integrity": "sha512-1bb8T4wJgd7/0YXV/TtoPq9cnxDzLkaNNbspxga91ksUdT7k2RwGAYo7TALORhTpj0Lyqu4Gn7UM+z4rq+ZCAg==",
+            "version": "2.1.0",
+            "resolved": "https://registry.npmjs.org/@reiryoku/ctrader-layer/-/ctrader-layer-2.1.0.tgz",
+            "integrity": "sha512-CQc12QPzhl6NCR51Uzgepd2AERKhwgSDxzRyVgjJ4j50IqOCkzqshJIXYW1pJIggmc3M3d01aAtv1HQJMQf09A==",
             "dependencies": {
                 "axios": "0.21.1",
                 "protobufjs": "5.0.1",
@@ -8204,9 +8204,9 @@
             }
         },
         "@reiryoku/ctrader-layer": {
-            "version": "2.0.0",
-            "resolved": "https://registry.npmjs.org/@reiryoku/ctrader-layer/-/ctrader-layer-2.0.0.tgz",
-            "integrity": "sha512-1bb8T4wJgd7/0YXV/TtoPq9cnxDzLkaNNbspxga91ksUdT7k2RwGAYo7TALORhTpj0Lyqu4Gn7UM+z4rq+ZCAg==",
+            "version": "2.1.0",
+            "resolved": "https://registry.npmjs.org/@reiryoku/ctrader-layer/-/ctrader-layer-2.1.0.tgz",
+            "integrity": "sha512-CQc12QPzhl6NCR51Uzgepd2AERKhwgSDxzRyVgjJ4j50IqOCkzqshJIXYW1pJIggmc3M3d01aAtv1HQJMQf09A==",
             "requires": {
                 "axios": "0.21.1",
                 "protobufjs": "5.0.1",

--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
         "tests"
     ],
     "dependencies": {
-        "@reiryoku/ctrader-layer": "^2.0.0"
+        "@reiryoku/ctrader-layer": "^2.1.0"
     },
     "devDependencies": {
         "@reiryoku/eslint-config-reiryoku": "^1.0.0",


### PR DESCRIPTION
### Features
* Update cTrader Layer to 2.1.0 to support browser usage.